### PR TITLE
Don't scroll to top if link was opened in new tab

### DIFF
--- a/src/components/SidebarItem/SidebarItem.jsx
+++ b/src/components/SidebarItem/SidebarItem.jsx
@@ -37,7 +37,7 @@ export default class SidebarItem extends Component {
   }
 
   scrollTop(event) {
-    if (!event.metaKey) {
+    if (!event.metaKey && !event.ctrlKey) {
         window.scrollTo(0, 0);
     }
   }

--- a/src/components/SidebarItem/SidebarItem.jsx
+++ b/src/components/SidebarItem/SidebarItem.jsx
@@ -36,8 +36,10 @@ export default class SidebarItem extends Component {
     );
   }
 
-  scrollTop() {
-    window.scrollTo(0, 0);
+  scrollTop(event) {
+    if (!event.metaKey) {
+        window.scrollTo(0, 0);
+    }
   }
 
   render() {


### PR DESCRIPTION
If user cmd+clicks (or ctrl+clicks) a link in the sidebar, the linked page opens in a new page, and the current tab should not scroll to the top.